### PR TITLE
Add `coqidetop.opt.exe` to path

### DIFF
--- a/coq.json
+++ b/coq.json
@@ -13,7 +13,8 @@
     "bin": [
         "bin\\coqtop.exe",
         "bin\\coqc.exe",
-        "bin\\coqchk.exe"
+        "bin\\coqchk.exe",
+        "bin\\coqidetop.opt.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
This is required for VSCoq plugin on VSCode. The name is unique enough so there should be no conflict.

This commit fix issue #1716 (https://github.com/ScoopInstaller/Main/issues/1716)