### PR TITLE
Remove dmtracedump.exe from platform tools 34.0.5

### DIFF
--- a/adb.json
+++ b/adb.json
@@ -10,7 +10,6 @@
     "hash": "3f8320152704377de150418a3c4c9d07d16d80a6c0d0d8f7289c22c499e33571",
     "bin": [
         "platform-tools\\adb.exe",
-        "platform-tools\\dmtracedump.exe",
         "platform-tools\\etc1tool.exe",
         "platform-tools\\fastboot.exe",
         "platform-tools\\hprof-conv.exe"


### PR DESCRIPTION
- dmtracedump.exe is not present in android platform tools https://dl.google.com/android/repository/platform-tools_r34.0.5-windows.zip
- Keeping this line will make the setup fail