### PR TITLE
Update uutils-coreutils.json: extracted folder without version

### DIFF
--- a/uutils-coreutils.json
+++ b/uutils-coreutils.json
@@ -451,17 +451,18 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-x86_64-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-$version-x86_64-pc-windows-msvc"
+                "extract_dir": "coreutils-x86_64-pc-windows-msvc"
             },
             "32bit": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-i686-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-$version-i686-pc-windows-msvc"
+                "extract_dir": "coreutils-i686-pc-windows-msvc"
             },
             "arm64": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-aarch64-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-$version-aarch64-pc-windows-msvc"
+                "extract_dir": "coreutils-aarch64-pc-windows-msvc"
             }
         }
     }
 }
+
 

--- a/uutils-coreutils.json
+++ b/uutils-coreutils.json
@@ -13,17 +13,17 @@
         "64bit": {
             "url": "https://github.com/uutils/coreutils/releases/download/0.6.0/coreutils-0.6.0-x86_64-pc-windows-msvc.zip",
             "hash": "f223058a51e8a2a4b92d9f1a1b2954f7a02b6d0f42e4a7e0413fcdb93be2e287",
-            "extract_dir": "coreutils-0.6.0-x86_64-pc-windows-msvc"
+            "extract_dir": "coreutils-x86_64-pc-windows-msvc"
         },
         "32bit": {
             "url": "https://github.com/uutils/coreutils/releases/download/0.6.0/coreutils-0.6.0-i686-pc-windows-msvc.zip",
             "hash": "4b95738775de79250af2ce4f1ca2ed88a31b37910b87b2b6f9f317755c9c1240",
-            "extract_dir": "coreutils-0.6.0-i686-pc-windows-msvc"
+            "extract_dir": "coreutils-i686-pc-windows-msvc"
         },
         "arm64": {
             "url": "https://github.com/uutils/coreutils/releases/download/0.6.0/coreutils-0.6.0-aarch64-pc-windows-msvc.zip",
             "hash": "7183bd5aff648b76517182e50d94819efdaede637650f5b9ad9117c171c4eebf",
-            "extract_dir": "coreutils-0.6.0-aarch64-pc-windows-msvc"
+            "extract_dir": "coreutils-aarch64-pc-windows-msvc"
         }
     },
     "bin": [
@@ -464,3 +464,4 @@
         }
     }
 }
+


### PR DESCRIPTION
Extracted folder of uutils-coreutils does not have version in its name for 0.6.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed version strings from extraction directory names for coreutils on Windows (64-bit, 32-bit, ARM64).
  * Applied the same directory-name change to the autoupdate extraction behavior so unpacked folders remain version-agnostic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->